### PR TITLE
IS-3059 - Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Brightpsace/parse-sqs-queue-url-action.git"
+    "url": "git+https://github.com/Brightspace/parse-sqs-queue-url-action.git"
   },
   "keywords": [
     "GitHub",
@@ -22,9 +22,9 @@
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Brightpsace/parse-sqs-queue-url-action/issues"
+    "url": "https://github.com/Brightspace/parse-sqs-queue-url-action/issues"
   },
-  "homepage": "https://github.com/Brightpsace/parse-sqs-queue-url-action#readme",
+  "homepage": "https://github.com/Brightspace/parse-sqs-queue-url-action#readme",
   "dependencies": {
     "@actions/core": "^1.10.1"
   },


### PR DESCRIPTION
Brightpsace -> Brightspace

For context, a security researcher found and reported this to us in hopes of getting a bounty. 